### PR TITLE
Fix no error when /config.json doesn't exist

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -62,7 +62,7 @@ func GoFileWalk(rootPath string, includePaths []string) (fileList []string, err 
 func LoadConfig() (config map[string]interface{}, err error) {
 	var parsedConfig map[string]interface{}
 
-	if _, err := os.Stat("/config.json"); err == nil {
+	if _, err = os.Stat("/config.json"); err == nil {
 		data, err := ioutil.ReadFile("/config.json")
 		if err != nil {
 			return nil, err
@@ -74,7 +74,7 @@ func LoadConfig() (config map[string]interface{}, err error) {
 		}
 	}
 
-	return parsedConfig, nil
+	return parsedConfig, err
 }
 
 func IncludePaths(rootPath string, config map[string]interface{}) []string {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -62,19 +62,21 @@ func GoFileWalk(rootPath string, includePaths []string) (fileList []string, err 
 func LoadConfig() (config map[string]interface{}, err error) {
 	var parsedConfig map[string]interface{}
 
-	if _, err = os.Stat("/config.json"); err == nil {
-		data, err := ioutil.ReadFile("/config.json")
-		if err != nil {
-			return nil, err
-		}
-		err = json.Unmarshal(data, &parsedConfig)
-
-		if err != nil {
-			return nil, err
-		}
+	if _, err := os.Stat("/config.json"); err != nil {
+		return nil, err
 	}
 
-	return parsedConfig, err
+	data, err := ioutil.ReadFile("/config.json")
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(data, &parsedConfig)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return parsedConfig, nil
 }
 
 func IncludePaths(rootPath string, config map[string]interface{}) []string {


### PR DESCRIPTION
I rewrote the `LoadConfig()` function to actually return an error when `os.Stat("/config.json")` failed.
The previous code declared a new `err` in the scope of the if statement, but then returned the empty one from the named return values. 